### PR TITLE
Add title to terminal.reader and make registration code numeric

### DIFF
--- a/api/terminal/index.ts
+++ b/api/terminal/index.ts
@@ -114,6 +114,7 @@ export type TerminalReader = {
   ip_address: string | null,
   label: string,
   livemode: boolean,
+  title: string,
   location: TerminalLocation | string | null,
   metadata: unknown /*map*/,
   object: 'terminal.reader',
@@ -404,7 +405,8 @@ export type Endpoints =
       label?: string,
       location?: string,
       metadata?: unknown /*map*/ | '',
-      registration_code: string,
+      registration_code: number,
+      title: string,
     },
     TerminalReader,
   ]


### PR DESCRIPTION
### Affected endpoints:

``` diff
post /v1/terminal/readers/{reader}
{...}
{
+  title: string,
}

get /v1/terminal/readers/{reader}
{...}
{
+  title: string,
}

delete /v1/terminal/readers/{reader}
{...}
{
+  title: string,
}

post /v1/terminal/readers
{
-  registration_code: string,
+  registration_code: number,
+  title: string,
}
{
+  title: string,
}

get /v1/terminal/readers
{...}
{
  data: [{
+      title: string,
    }],
}

post /v1/terminal/readers/{reader}/process_payment_intent
{...}
{
+  title: string,
}

post /v1/terminal/readers/{reader}/process_setup_intent
{...}
{
+  title: string,
}

post /v1/terminal/readers/{reader}/cancel_action
{...}
{
+  title: string,
}

post /v1/terminal/readers/{reader}/set_reader_display
{...}
{
+  title: string,
}

post /v1/terminal/readers/{reader}/refund_payment
{...}
{
+  title: string,
}

```

### Warnings
 - ⚠️ Changing request value type is a breaking change
 - ⚠️ Adding required request properties is breaking change
